### PR TITLE
무기 장착/해제 시 캐릭터의 Link Weapon Anim Layer 기능 관련 개선

### DIFF
--- a/Source/FlashPoint/AbilitySystem/FPAbilitySystemComponent.cpp
+++ b/Source/FlashPoint/AbilitySystem/FPAbilitySystemComponent.cpp
@@ -27,6 +27,11 @@ void UFPAbilitySystemComponent::InitAbilityActorInfo(AActor* InOwnerActor, AActo
 		{
 			FPAnimInstance->InitializeWithAbilitySystem(this);
 		}
+		
+		if (UWeaponManageComponent* WeaponManageComponent = InAvatarActor->FindComponentByClass<UWeaponManageComponent>())
+		{
+			WeaponManageComponent->InitializeWithAbilitySystem(this);
+		}
 	}
 }
 

--- a/Source/FlashPoint/Character/FPCharacter.cpp
+++ b/Source/FlashPoint/Character/FPCharacter.cpp
@@ -166,12 +166,6 @@ void AFPCharacter::SetCharacterMesh()
 			}
 		}
 	}
-	
-	// Anim Layer
-	if (UAnimInstance* AnimInstance = GetMesh()->GetAnimInstance())
-	{
-		AnimInstance->LinkAnimClassLayers(CosmeticData->GetDefaultAnimLayer());
-	}
 }
 
 void AFPCharacter::InitAbilitySystem()

--- a/Source/FlashPoint/Weapon/WeaponManageComponent.h
+++ b/Source/FlashPoint/Weapon/WeaponManageComponent.h
@@ -40,6 +40,8 @@ public:
 	UWeaponManageComponent();
 	virtual void GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const override;
 	virtual void InitializeComponent() override;
+	
+	void InitializeWithAbilitySystem(UAbilitySystemComponent* ASC);
 
 	AWeapon_Base* GetEquippedWeapon() const { return EquippedWeapon; }
 
@@ -115,6 +117,17 @@ private:
 
 	UFUNCTION()
 	void OnRep_WeaponEquipStateUpdateCounter();
+	
+	// 캐릭터에 적용할 무기 장착 로직을 처리한다.
+	// WeaponAnimLayer를 연결하고 WeaponEquipMontage를 재생한다.
+	void HandleWeaponEquip(AWeapon_Base* Weapon, bool bIsEquip = false);
+	
+	// EquipMontage or UnEquipMontage가 종료되면 발사를 막는 태그를 제거하도록 등록
+	void BindMontageEndedDelegate(UAnimMontage* Montage);
+	FOnMontageEnded OnMontageEndedDelegate;
+
+	// 발사를 막는 태그를 업데이트한다.
+	void UpdateFireBlockTag(bool bBlockFire) const;
 
 	// ============================================================================
 	// Tag Stacks
@@ -158,12 +171,19 @@ public:
 private:
 	UPROPERTY()
 	TObjectPtr<ACharacter> OwnerCharacter;
+	
+	UPROPERTY()
+	TObjectPtr<USkeletalMeshComponent> OwnerCharacterMesh;
 
 	UPROPERTY()
 	TObjectPtr<UCharacterMovementComponent> OwnerCharacterMoveComponent;
 
+	// 서버와 클라에서 InitializeWithAbilitySystem()에 의해 캐싱된다.
 	UPROPERTY()
-	TObjectPtr<UAbilitySystemComponent> OwnerAbilitySystemComponent;
+	TObjectPtr<UAbilitySystemComponent> OwnerASC;
+	
+	UPROPERTY()
+	TSubclassOf<UAnimInstance> CurrentWeaponAnimLayerClass;
 
 	// 현재 장착한 무기의 RecoilData
 	UPROPERTY()

--- a/Source/FlashPoint/Weapon/Weapon_Base.cpp
+++ b/Source/FlashPoint/Weapon/Weapon_Base.cpp
@@ -4,16 +4,11 @@
 #include "Weapon_Base.h"
 
 #include "AbilitySystemBlueprintLibrary.h"
-#include "AbilitySystemComponent.h"
 #include "FPGameplayTags.h"
-#include "FPLogChannels.h"
 #include "NiagaraComponent.h"
 #include "NiagaraDataInterfaceArrayFunctionLibrary.h"
 #include "NiagaraFunctionLibrary.h"
 #include "AbilitySystem/FPAbilitySystemComponent.h"
-#include "Data/FPCosmeticData.h"
-#include "GameFramework/Character.h"
-#include "System/FPAssetManager.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(Weapon_Base) 
 
@@ -30,12 +25,6 @@ AWeapon_Base::AWeapon_Base()
 	BulletsPerCartridge = 1;
 	HeadShotMultiplier = 1.f;
 
-	// EquipMontage or UnEquipMontage가 종료되면 발사를 막는 태그를 제거하도록 등록
-	OnMontageEndedDelegate.BindWeakLambda(this, [this](UAnimMontage* Montage, bool bInterrupted)
-	{
-		UpdateFireBlockTag(false);
-	});
-
 	LeftHandAttachSocketName = TEXT("LeftHandSocket");
 }
 
@@ -51,13 +40,6 @@ FTransform AWeapon_Base::GetLeftHandAttachTransform() const
 
 void AWeapon_Base::OnEquipped()
 {
-	LinkWeaponAnimLayer(false);
-	PlayOwningCharacterMontage(EquipInfo.EquipMontage);
-
-	// 총기 발사 관리
-	BindMontageEndedDelegate(EquipInfo.EquipMontage);
-	UpdateFireBlockTag(true);
-
 	GetWorldTimerManager().SetTimer(ShowWeaponTimerHandle, FTimerDelegate::CreateLambda([this]()
 	{
 		WeaponMeshComponent->SetHiddenInGame(false);
@@ -71,13 +53,6 @@ void AWeapon_Base::OnUnEquipped()
 		// 무기 발사 입력 Flush
 		ASC->FlushPressedInput(FPGameplayTags::Input::Gameplay::WeaponFire);
 	}
-	
-	LinkWeaponAnimLayer(true);
-	PlayOwningCharacterMontage(EquipInfo.UnEquipMontage);
-
-	// 총기 발사 관리
-	BindMontageEndedDelegate(EquipInfo.UnEquipMontage);
-	UpdateFireBlockTag(true);
 
 	WeaponMeshComponent->SetHiddenInGame(true);
 }
@@ -132,55 +107,4 @@ float AWeapon_Base::GetDamageByDistance(float Distance) const
 UAbilitySystemComponent* AWeapon_Base::GetOwnerASC() const
 {
 	return UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(GetOwner());
-}
-
-void AWeapon_Base::LinkWeaponAnimLayer(bool bUseDefault) const
-{
-	const UFPCosmeticData* CosmeticData = UFPAssetManager::GetAssetById<UFPCosmeticData>(TEXT("CosmeticData"));
-	check(CosmeticData);
-
-	if (ACharacter* OwningCharacter = GetOwner<ACharacter>())
-	{
-		if (USkeletalMeshComponent* OwnerMeshComponent = OwningCharacter->GetMesh())
-		{
-			TSubclassOf<UAnimInstance> Class = bUseDefault ? CosmeticData->GetDefaultAnimLayer() : CosmeticData->SelectAnimLayer(EquipInfo.CosmeticTags); 
-			OwnerMeshComponent->LinkAnimClassLayers(Class);
-		}
-	}
-}
-
-void AWeapon_Base::PlayOwningCharacterMontage(UAnimMontage* MontageToPlay)
-{
-	if (ACharacter* OwningCharacter = GetOwner<ACharacter>())
-	{
-		OwningCharacter->PlayAnimMontage(MontageToPlay);
-	}
-}
-
-void AWeapon_Base::BindMontageEndedDelegate(UAnimMontage* Montage)
-{
-	if (ACharacter* OwningCharacter = GetOwner<ACharacter>())
-	{
-		USkeletalMeshComponent* MeshComp = OwningCharacter->GetMesh();
-		if (UAnimInstance* AnimInstance = MeshComp ? MeshComp->GetAnimInstance() : nullptr)
-		{
-			// Weak Lambda to call UpdateFireBlockTag(false)
-			AnimInstance->Montage_SetEndDelegate(OnMontageEndedDelegate, Montage);			
-		}
-	}
-}
-
-void AWeapon_Base::UpdateFireBlockTag(bool bBlockFire) const
-{
-	if (UAbilitySystemComponent* ASC = GetOwnerASC())
-	{
-		if (bBlockFire)
-		{
-			ASC->AddLooseGameplayTag(FPGameplayTags::Weapon::NoFire);
-		}
-		else
-		{
-			ASC->RemoveLooseGameplayTag(FPGameplayTags::Weapon::NoFire);
-		}
-	}
 }

--- a/Source/FlashPoint/Weapon/Weapon_Base.h
+++ b/Source/FlashPoint/Weapon/Weapon_Base.h
@@ -101,16 +101,6 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category="FlashPoint|Equip")
 	FWeaponEquipInfo EquipInfo;
 
-	void LinkWeaponAnimLayer(bool bUseDefault) const;
-	void PlayOwningCharacterMontage(UAnimMontage* MontageToPlay);
-
-	// EquipMontage or UnEquipMontage가 종료되면 발사를 막는 태그를 제거하도록 등록
-	void BindMontageEndedDelegate(UAnimMontage* Montage);
-	FOnMontageEnded OnMontageEndedDelegate;
-
-	// 발사를 막는 태그를 업데이트한다.
-	void UpdateFireBlockTag(bool bBlockFire) const;
-
 	// 일정 시간 뒤 무기를 다시 표시할 때 사용
 	FTimerHandle ShowWeaponTimerHandle;
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->


## 📄 작업 내용 요약
- 새로운 무기의 Anim Layer를 등록하기 전 기존에 등록된 Anim Layer를 해제하도록 개선
- 캐릭터의 Anim Layer 연결과 몽타주 재생을 AWeapon_Base 대신 UWeaponManageComponent에서 수행하도록 이전
- 장착/해제 시 무기 발사를 막는 태그 관리 기능 또한 이전
- 초기 캐릭터의 Unarmed Anim Layer 설정도 이전
- UWeaponManageComponent의 BeginPlay에서 필요한 포인터들을 캐싱할 때 서버와 클라 모두 수행하도록 변경
- AbilitySystemComponent는 UFPAbilitySystemComponent에서 주입 형식으로 캐싱하도록 변경