### PR TITLE
벽에 붙어 전방으로 이동할 때 전방 이동 애니메이션이 재생되지 않는 문제 해결

### DIFF
--- a/Source/FlashPoint/Animation/FPAnimInstance.cpp
+++ b/Source/FlashPoint/Animation/FPAnimInstance.cpp
@@ -88,7 +88,7 @@ void UFPAnimInstance::NativeThreadSafeUpdateAnimation(float DeltaSeconds)
 			
 			Velocity = MoveComponent->Velocity;
 			GroundSpeed = Velocity.Size2D();
-			DirectionAngle = UKismetAnimationLibrary::CalculateDirection(Velocity, WorldRotation);
+			DirectionAngle = UKismetAnimationLibrary::CalculateDirection(MoveComponent->GetCurrentAcceleration(), WorldRotation);
 			
 			bShouldMove = GroundSpeed > 0.f && MoveComponent->GetCurrentAcceleration() != FVector::ZeroVector;
 			bIsOnGround = MoveComponent->IsMovingOnGround();
@@ -156,7 +156,7 @@ void UFPAnimInstance::UpdateCurrentDirection()
 	float BwdDeadZone = CardinalDirectionDeadZone;
 
 	// Was Moving
-	if (Velocity.Size2D() > 0.f)
+	if (GroundSpeed > 0.f)
 	{
 		// 앞 또는 뒤로 이동 중이면 진행 방향을 벗어나기 힘들도록 DeadZone을 키움
 		switch (CurrentDirection)


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#113 

## 📄 작업 내용 요약
- 이동 애니메이션 방향을 결정할 때 필요한 DirectionAngle 값을 기존에는 Velocity를 통해 계산했는데 그럴 경우 벽에 붙은 채로 전방으로 이동하면 좌우 속도를 나타내는 X축 값만 유지되기 때문에 좌우 애니메이션이 재생됨
- Velocity 대신 벽에 붙은 채로 이동해도 모든 축의 값이 유지되는 Acceleration을 사용하도록 변경